### PR TITLE
docs(README): `actions/checkout@v{version_number}` -> `actions/checkout@{version_number}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # octoherd-script-update-action-version-in-workflows
 
-> Update workflows using a certain GitHub Action to a concrete version, i.e. actions/checkout@v{version_number}
+> Update workflows using a certain GitHub Action to a concrete version, i.e. actions/checkout@{version_number}
 
 [![@latest](https://img.shields.io/npm/v/octoherd-script-update-action-version-in-workflows.svg)](https://www.npmjs.com/package/octoherd-script-update-action-version-in-workflows)
 [![Build Status](https://github.com/oscard0m/octoherd-script-update-action-version-in-workflows/workflows/Test/badge.svg)](https://github.com/oscard0m/octoherd-script-update-action-version-in-workflows/actions?query=workflow%3ATest+branch%3Amain)


### PR DESCRIPTION
I think the `v` is included in the `version_number` argument, right?